### PR TITLE
feat(drills): implement drill post form (日常のひとコマ練習ページ) (#11)

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,1 +1,41 @@
 @import "tailwindcss";
+
+/* v4 方式のテーマ定義 */
+@theme {
+  /* Colors */
+  --color-background: #F8F9FA;
+  --color-primaryOrange: #FFB347;
+  --color-accentBlue: #4A90E2;
+  --color-neutralGray: #E0E0E0;
+  --color-surface: #FFFFFF;
+  --color-textPrimary: #222222;
+  --color-textSecondary: #555555;
+
+  /* Radius */
+  --radius-lg: 16px;
+  --radius-sm: 8px;
+
+  /* Shadow */
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
+
+  /* Typography (必要なら) */
+  --text-heading-lg: 20px;
+  --leading-heading-lg: 28px;
+  --text-body-md: 14px;
+  --leading-body-md: 20px;
+  --text-label-sm: 12px;
+  --leading-label-sm: 16px;
+}
+
+/* 便利クラス（任意） */
+@layer components {
+  .btn-primary {
+    @apply w-full h-12 rounded-lg bg-primaryOrange text-white text-body-md font-medium;
+  }
+  .btn-secondary {
+    @apply w-full h-12 rounded-lg bg-neutralGray text-textPrimary text-body-md font-medium;
+  }
+  .card {
+    @apply bg-surface rounded-lg shadow-sm border border-neutralGray;
+  }
+}

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,23 +1,66 @@
 # app/controllers/posts_controller.rb
 class PostsController < ApplicationController
-  def index
-    @tip = find_tip!
-    @posts = @tip.posts.order(created_at: :desc).limit(50).includes(:tip)
+  helper_method :posts_enabled?   # ← 追加
 
+  def new
+    @tip  = find_target_tip
+    @post = Post.new
+  end
+
+  def create
+    @tip  = find_target_tip
+
+    unless posts_enabled?
+      flash[:alert] = "現在、投稿は一時停止中です。"
+      return redirect_to practice_path(tip_id: @tip&.id)
+    end
+
+    @post = Post.new(post_params.merge(tip_id: @tip&.id))
+
+    if @tip.nil?
+      flash.now[:alert] = "投稿対象のひとことが見つかりません。"
+      @post = Post.new
+      return render :new, status: :unprocessable_entity
+    end
+
+    if @post.save
+      session[:last_post_id] = @post.id
+      redirect_to drills_path(tip_id: @tip.id, highlight_post_id: @post.id),
+                  notice: "投稿しました。"
+    else
+      flash.now[:alert] = "投稿に失敗しました。入力内容をご確認ください。"
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def index
+    @tip = find_target_tip
+    @posts = @tip ? @tip.posts.order(created_at: :desc).limit(50).includes(:tip) : Post.none
     @highlight_post_id = params[:highlight_post_id].presence || session[:last_post_id]
 
-    @prev_tip = Tip.where("scheduled_date < ?", @tip.scheduled_date).order(scheduled_date: :desc).first
-    @next_tip = Tip.where("scheduled_date > ?", @tip.scheduled_date).order(scheduled_date: :asc).first
+    if @tip
+      @prev_tip = Tip.where("scheduled_date < ?", @tip.scheduled_date).order(scheduled_date: :desc).first
+      @next_tip = Tip.where("scheduled_date > ?", @tip.scheduled_date).order(scheduled_date: :asc).first
+    end
   end
 
   private
 
-  # 今日のTIPが無ければ直近の公開済TIPを返す
-  def find_tip!
-    return Tip.find(params[:tip_id]) if params[:tip_id].present?
+  # ENVから安全に真偽値を解釈
+  def posts_enabled?
+    ActiveModel::Type::Boolean.new.cast(ENV["ENABLE_POSTS"])
+  end
+
+  # /drills と /practice の双方で使う “対象TIP決定（今日→直近→最古の保険）”
+  def find_target_tip
+    return Tip.find_by(id: params[:tip_id]) if params[:tip_id].present?
 
     Tip.find_by(scheduled_date: Date.current) ||
       Tip.where("scheduled_date <= ?", Date.current).order(scheduled_date: :desc).first ||
-      Tip.order(scheduled_date: :asc).first # データ完全空の保険
+      Tip.order(scheduled_date: :asc).first
+  end
+
+  def post_params
+    params.require(:post).permit(:content, :display_nickname)
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -4,5 +4,5 @@ class Post < ApplicationRecord
   validates :content, presence: true, length: { maximum: 150 }
   validates :display_nickname, length: { maximum: 30 }, allow_blank: true
 
-  scope :recent, -> { order(created_at: :desc) }
+  # scope :recent, -> { order(created_at: :desc) }
 end

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,4 +1,72 @@
-<!-- app/views/posts/new.html.erb -->
 <%= render "shared/common_header" %>
-<main class="p-4">練習ページ（準備中）</main>
+
+<main class="bg-background min-h-screen pb-20 px-4 pt-4">
+  <section class="mb-4">
+    <h1 class="text-heading-lg font-semibold text-textPrimary">日常のひとコマで練習</h1>
+    <% if @tip %>
+      <p class="text-body-md text-textSecondary mt-1">
+        今日のひとこと：<span class="text-textPrimary"><%= @tip.content %></span>
+      </p>
+    <% else %>
+      <p class="text-body-md text-textSecondary mt-1">投稿対象のひとことが見つかりません。</p>
+    <% end %>
+  </section>
+
+  <!-- シーン説明カード -->
+  <section class="bg-surface shadow-sm rounded-lg p-4 border border-neutralGray mb-4">
+    <p class="text-body-md text-textPrimary">
+      会議前のアイスブレイク。隣の人が同じペンを使っているのに気づいたとき、どう声をかけますか？
+    </p>
+  </section>
+
+  <% if flash[:notice] %>
+    <div class="mb-3 text-label-sm text-accentBlue"><%= flash[:notice] %></div>
+  <% end %>
+  <% if flash[:alert] %>
+    <div class="mb-3 text-label-sm text-[#c0392b]"><%= flash[:alert] %></div>
+  <% end %>
+
+  <!-- ★ 投稿停止中の案内を追加 -->
+<% unless posts_enabled? %>
+  <div class="mb-4 p-3 rounded bg-neutralGray text-label-sm text-textSecondary">
+    現在、投稿は一時停止中です（画面表示や遷移のみ確認できます）。
+  </div>
+<% end %>
+
+  <%= form_with url: practice_path,
+              scope: :post,
+              method: :post,
+              data: { turbo: false },
+              class: "space-y-4" do |f| %>
+    <%= hidden_field_tag :tip_id, @tip&.id %>
+
+    <!-- 自由入力 150字 -->
+    <div>
+      <label class="block text-label-sm text-textSecondary mb-1">回答（150字）</label>
+      <%= f.text_area :content,
+            maxlength: 150,
+            rows: 5,
+            required: true,
+            class: "w-full h-28 rounded-sm border border-neutralGray px-4 py-2 text-body-md text-textPrimary bg-surface" %>
+      <p class="text-label-sm text-textSecondary mt-1">※ 150字以内で入力してください</p>
+    </div>
+
+    <!-- ニックネーム -->
+    <div>
+      <label class="block text-label-sm text-textSecondary mb-1">ニックネーム</label>
+      <%= f.text_field :display_nickname,
+            placeholder: "例）まさくん",
+            class: "w-full h-11 rounded-sm border border-neutralGray px-4 text-body-md text-textPrimary bg-surface" %>
+    </div>
+
+    <%= f.submit "書いてみる",
+      disabled: !posts_enabled?,
+      class: [
+        "w-full h-12 rounded-lg text-body-md font-medium transition",
+        posts_enabled? ? "bg-primaryOrange text-white hover:bg-[#FF9F2E]" :
+                         "bg-neutralGray text-textSecondary opacity-60 cursor-not-allowed"
+      ].join(" ") %>
+  <% end %>
+</main>
+
 <%= render "shared/common_footer" %>

--- a/compose.yml
+++ b/compose.yml
@@ -27,6 +27,7 @@ services:
       - node_modules:/myapp/node_modules
     environment:
       TZ: Asia/Tokyo
+      ENABLE_POSTS: "1"   # ← これを追加（文字列でOK）
     ports:
       - "3000:3000"
     depends_on:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,15 +17,14 @@ Rails.application.routes.draw do
   # root "posts#index"
 
   # 今日のひとこと（今日 or 最寄りTipを1件表示）
-  # get  "today",    to: "phrases#today", as: :today_phrase
   get "today", to: "tips#today"
-
   get "practice", to: "posts#new"      # 練習ページ（投稿作成）
   get "drills",   to: "posts#index"    # みんなのひとこと（投稿一覧）
   get "dashboard", to: "pages#dashboard" # マイページ（仮）
 
-  # タイムライン（当日 or 直近Tipに紐づく投稿一覧）
-  # get "timeline", to: "posts#index",   as: :timeline
+  # ひとコマ練習ページ（投稿フォーム）
+  get  "practice", to: "posts#new"
+  post "practice", to: "posts#create"
 
   # 投稿作成のみ許可（MVP）
   resources :posts, only: [ :create ]


### PR DESCRIPTION
## ✨ PR 概要

* **日常のひとコマ投稿機能（#12）** を実装
* 追加で **投稿の一時停止機能（環境変数制御）** を導入

---

## 🔍 変更内容

### 投稿機能の実装

* `/drills` に「みんなのひとこと」一覧を表示

  * `@tip.posts` を新着順に最大50件表示
  * 新規投稿後は自分の投稿をハイライト
* `/practice` に投稿フォームを追加

  * 今日の TIP に紐づけて投稿可能
  * ニックネーム入力欄を用意（任意入力）
  * 投稿完了後は `/drills` にリダイレクト

### 投稿停止モード

* 環境変数 `ENABLE_POSTS` により投稿を制御

  * `ENABLE_POSTS=0` → 投稿停止（安全モード）
  * `ENABLE_POSTS=1` → 通常通り投稿可能
* 停止時の挙動

  * フォーム上に「現在投稿は停止中です」と案内を表示
  * 投稿ボタンをグレーアウトして押せない状態に

---

## 🚀 運用フロー

1. **開発環境**

   * `compose.yml` に `ENABLE_POSTS=1` を指定 → 常に投稿可能
2. **本番環境（Render）**

   * Environment Variables で制御

     * 初回デプロイ時は `ENABLE_POSTS=0` で安全に稼働確認
     * 検証後に `ENABLE_POSTS=1` に切替 → 投稿解放

---

## ✅ 確認項目

* [ ] 投稿が正常に保存・リダイレクトされる
* [ ] 投稿一覧に新規投稿が表示され、ハイライトされる
* [ ] `ENABLE_POSTS=0` で投稿フォームが停止表示になる
* [ ] `ENABLE_POSTS=1` で通常通り投稿できる

---

## 📝 備考

* MVP 段階のためログイン認証は未実装
* 将来的にログイン機能を導入し、投稿制御を移行予定

