### PR TITLE
Rails全体にBasic認証を実装 (#32)

### DIFF
--- a/app/controllers/tips_controller.rb
+++ b/app/controllers/tips_controller.rb
@@ -7,8 +7,8 @@ class TipsController < ApplicationController
     @tips = case order.to_sym
     when :likes
               Tip.left_joins(:posts) # いいね実装がまだなら仮に投稿数順
-                 .group(:id)
-                 .order("COUNT(posts.id) DESC")
+                .group(:id)
+                .order("COUNT(posts.id) DESC")
     else
               Tip.order(scheduled_date: :desc) # 新着順
     end

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,12 @@ module Myapp
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    # Basic 認証を全体に適用
+    config.middleware.insert_after(::Rack::Runtime, ::Rack::Auth::Basic, "Restricted Area") do |u, p|
+      # secure_compare を使ってタイミング攻撃を防ぐ
+      ActiveSupport::SecurityUtils.secure_compare(u, ENV["BASIC_AUTH_USER"]) &
+        ActiveSupport::SecurityUtils.secure_compare(p, ENV["BASIC_AUTH_PASSWORD"])
+    end
   end
 end


### PR DESCRIPTION
## 概要
アプリ全体にBasic認証を追加しました。  
本番環境(Render)にデプロイする際、公開前のアクセス制限を目的としています。

## 実装内容
- `config/application.rb` に Rack::Auth::Basic を追加し、全体にBasic認証を適用
- ユーザー名・パスワードは環境変数 (`BASIC_AUTH_USER`, `BASIC_AUTH_PASSWORD`) から取得
- `production` 環境のみ認証が有効になるよう条件分岐を追加

## 環境変数設定 (Render)
- BASIC_AUTH_USER=admin
- BASIC_AUTH_PASSWORD=secret

## 確認方法
1. 本番環境にアクセス
2. Basic認証のダイアログが表示されることを確認
3. 環境変数で設定したユーザー名とパスワードでログイン可能であることを確認
