### PR TITLE
Basic認証の本番限定化とTailwind v4ユーティリティ修正

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -4,8 +4,8 @@
 @theme {
   /* Colors */
   --color-background: #F8F9FA;
-  --color-primary: #FFB347;          /* ← bg-primary 用に追加 */
-  --color-primaryOrange: #FFB347;
+  --color-primary: #FFB347;
+  --color-primaryOrange: #FFB347; /* 同値なら後で整理推奨 */
   --color-accentBlue: #4A90E2;
   --color-neutralGray: #E0E0E0;
   --color-surface: #FFFFFF;
@@ -19,18 +19,19 @@
   /* Shadow */
   --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
 
-  /* Typography (v4は font-size/line-height) */
+  /* Typography */
   --font-size-heading-lg: 20px;
   --line-height-heading-lg: 28px;
 
-  --font-size-body-md: 14px;     /* ← これが text-body-md になります */
+  --font-size-body-md: 14px;
   --line-height-body-md: 20px;
 
-  --font-size-label-sm: 12px;    /* ← これが text-label-sm になります */
+  --font-size-label-sm: 12px;
   --line-height-label-sm: 16px;
 }
 
-/* 明示ユーティリティ（保険：テーマ自動生成が効かない環境でも確実に作る） */
+/* ===== Utilities ===== */
+/* v4 では @utility で独自ユーティリティを定義してから @apply 可能 */
 @utility text-body-md {
   font-size: var(--font-size-body-md);
   line-height: var(--line-height-body-md);
@@ -39,19 +40,15 @@
   font-size: var(--font-size-label-sm);
   line-height: var(--line-height-label-sm);
 }
+@utility btn-text {
+  @apply text-body-md font-medium;
+}
 
 /* ===== Components ===== */
 @layer components {
-  /* ボタンのベース文字（14/20, Medium） */
-  .btn-text {
-    @apply text-body-md font-medium;
-  }
-
   .btn-primary {
-    @apply inline-flex items-center justify-center w-full
-           h-12 px-4
-           rounded-lg bg-primary text-white font-semibold
-           transition;
+    @apply inline-flex items-center justify-center w-full h-12 px-4
+           rounded-lg bg-primary text-white font-semibold transition;
     @apply btn-text;
   }
 
@@ -62,8 +59,7 @@
 
   /* 前後ナビ（アウトライン・pill） */
   .nav-pill {
-    @apply inline-flex items-center justify-center
-           h-10 px-4
+    @apply inline-flex items-center justify-center h-10 px-4
            rounded-full border border-accentBlue text-accentBlue
            hover:bg-blue-50 transition;
     @apply text-label-sm font-medium;

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,34 +1,30 @@
+# config/application.rb
 require_relative "boot"
-
 require "rails/all"
 
-# Require the gems listed in Gemfile, including any gems
-# you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
 module Myapp
   class Application < Rails::Application
-    # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.2
 
-    # Please, add to the `ignore` list any other `lib` subdirectories that do
-    # not contain `.rb` files, or that should not be reloaded or eager loaded.
-    # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w[assets tasks])
 
-    # Configuration for the application, engines, and railties goes here.
-    #
-    # These settings can be overridden in specific environments using the files
-    # in config/environments, which are processed later.
-    #
-    # config.time_zone = "Central Time (US & Canada)"
-    # config.eager_load_paths << Rails.root.join("extras")
+    # --- Basic 認証（本番のみ）。ENV 未設定ならミドルウェアを積まない ---
+    if Rails.env.production?
+      user = ENV["BASIC_AUTH_USERNAME"] || ENV["BASIC_AUTH_USER"]
+      pass = ENV["BASIC_AUTH_PASSWORD"]
 
-    # Basic 認証を全体に適用
-    config.middleware.insert_after(::Rack::Runtime, ::Rack::Auth::Basic, "Restricted Area") do |u, p|
-      # secure_compare を使ってタイミング攻撃を防ぐ
-      ActiveSupport::SecurityUtils.secure_compare(u, ENV["BASIC_AUTH_USER"]) &
-        ActiveSupport::SecurityUtils.secure_compare(p, ENV["BASIC_AUTH_PASSWORD"])
-    end
-  end
-end
+      if user.present? && pass.present?
+        user_digest = ::Digest::SHA256.hexdigest(user)
+        pass_digest = ::Digest::SHA256.hexdigest(pass)
+
+        config.middleware.insert_after(::Rack::Runtime, ::Rack::Auth::Basic, "Restricted Area") do |u, p|
+          ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(u.to_s), user_digest) &&
+            ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(p.to_s), pass_digest)
+        end # ← do ... end（ミドルウェアブロック）
+      end   # ← if user.present? && pass.present?
+    end     # ← if Rails.env.production?
+    # -----------------------------------------------------------------------
+  end       # ← class Application
+end         # ← module Myapp


### PR DESCRIPTION
### 概要

* Basic認証の設定を修正し、以下を対応しました

  * `ENV` 未設定時に `nil.bytesize` が発生する問題を解消
  * `Rails.env.production?` で本番環境のみ有効化
  * `hexdigest + to_s` を利用し、安全に比較するよう改善

* Tailwind v4 移行に伴い、未定義クラス `btn-text` / `text-body-md` / `text-label-sm` を修正

  * `@utility` を追加し、カスタムユーティリティとして定義
  * ボタン系クラスで `@apply` が正常に動作するよう調整

### 動作確認

* ローカル開発環境では Basic認証が無効化され、通常通りアクセス可能
* 本番環境では ENV を設定すると認証が有効になることを確認
* Tailwind ビルドが成功し、`btn-primary` / `btn-secondary` / `nav-pill` の見た目が期待通り表示されることを確認

### 補足

* ENV 名は `BASIC_AUTH_USERNAME` / `BASIC_AUTH_PASSWORD` を推奨
* 今後デプロイ時のビルドエラー対応を別PRで行う予定

close #43 