### PR TITLE
feat(tips/ui): 新カラム対応（title/description/practice_description）＋ビュー置換＆JST表示

### DIFF
--- a/app/controllers/tips_controller.rb
+++ b/app/controllers/tips_controller.rb
@@ -1,23 +1,39 @@
+# frozen_string_literal: true
+
 # app/controllers/tips_controller.rb
+#
+# ユーザー向け TIP 一覧/参照用コントローラ
+# - index: 並び替え（recent/likes）に対応
+# - show: 既存のドリル画面へリダイレクト（tips#show は使わず drills#show 相当へ委譲）
+# - show_today: 指定日（未指定なら今日）の TIP を表示し、前後ナビ用に隣接 TIP も取得
 class TipsController < ApplicationController
+  ORDER_OPTIONS = %i[recent likes].freeze
+
   def index
-    order = params[:order]&.to_sym || :recent
+    @order = _order_param
 
     @tips =
-      case order
+      case @order
       when :likes
-        Tip.left_joins(:posts).group(:id).order("COUNT(posts.id) DESC")
+        # 投稿数の多い順（NULL 安全のため LEFT JOIN）。N+1 を避けるため includes は不要。
+        Tip.left_joins(:posts)
+           .select("tips.*, COUNT(posts.id) AS posts_count")
+           .group(:id)
+           .order("COUNT(posts.id) DESC")
       else
+        # 既定: 日付の新しい順
         Tip.order(scheduled_date: :desc)
       end
   end
 
   def show
     tip = Tip.find(params[:id])
+    # 旧実装互換: ドリル詳細（みんなのひとこと）へ委譲
     redirect_to drills_path(tip_id: tip.id)
   end
 
-  # 今日/任意日表示（あなたが入れた新実装）
+  # 今日/任意日表示
+  # GET /tips/today?date=2025-08-26
   def show_today
     base_date = _parse_date(params[:date]) || Time.zone.today
     @tip = Tip.on(base_date).first
@@ -30,8 +46,22 @@ class TipsController < ApplicationController
 
   private
 
+  # 並び替えパラメータのサニタイズ
+  # @return [Symbol] :recent or :likes
+  def _order_param
+    key = params[:order]&.to_sym
+    return key if ORDER_OPTIONS.include?(key)
+    :recent
+  end
+
+  # date パラメータを Date にパース（失敗時は nil）
+  # @param [String] raw
+  # @return [Date, nil]
   def _parse_date(raw)
     return if raw.blank?
-    Date.parse(raw) rescue nil
+
+    Date.parse(raw)
+  rescue ArgumentError
+    nil
   end
 end

--- a/app/models/tip.rb
+++ b/app/models/tip.rb
@@ -4,7 +4,7 @@
 # Table name: tips
 #
 #  id                    :bigint           not null, primary key
-#  content               :text             not null
+#  content               :text             not null         # DEPRECATED: 近く削除予定
 #  scheduled_date        :date             not null, indexed (unique)
 #  title                 :string           not null
 #  description           :text             not null
@@ -19,6 +19,7 @@
 # NOTE:
 #  - 1日1TIPの運用前提。前後ナビ（previous/next）や「今日のTIP」取得を想定。
 #  - posts が紐づくため、削除時は関連もまとめて削除する。
+#  - 表示/入力は title, description, practice_description を中核として利用する。
 class Tip < ApplicationRecord
   TITLE_MAX = 120
 
@@ -27,10 +28,11 @@ class Tip < ApplicationRecord
 
   # バリデーション
   validates :scheduled_date, presence: true, uniqueness: true
-  validates :content, presence: true
   validates :title, presence: true, length: { maximum: TITLE_MAX }
   validates :description, presence: true
   validates :practice_description, presence: true
+  # content は移行完了後にカラム自体を削除予定のため、ここではバリデーションしない
+  # TODO: content カラム削除後、このコメントを除去する
 
   # スコープ（よく使うクエリ）
   scope :ordered, -> { order(scheduled_date: :asc) }

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -4,18 +4,21 @@
   <% if @tip.present? %>
     <section class="mb-4">
       <h1 class="text-heading-lg font-semibold text-textPrimary">みんなのひとこと</h1>
-      <p class="text-body-md text-textSecondary mt-1"><%= @tip.content %></p>
+      <!-- 旧: @tip.content → 新: @tip.title -->
+      <p class="text-body-md text-textSecondary mt-1"><%= h @tip.title %></p>
     </section>
 
     <section class="space-y-3">
       <% @posts.each do |post| %>
         <% highlighted = (@highlight_post_id.to_i == post.id) %>
+
+        <!-- ハイライトは青枠。青地にしたい場合は article の class を下のコメントのとおり変更 -->
         <article class="bg-surface shadow-sm rounded-lg p-4 border <%= highlighted ? 'border-accentBlue' : 'border-neutralGray' %>">
           <div class="flex items-center justify-between mb-2">
             <div class="flex items-center gap-2">
               <%= lucide_icon("circle-user", class: "w-5 h-5 text-textSecondary") %>
               <span class="text-label-sm text-textSecondary">
-                <%= post.display_nickname.presence || "名無しさん" %>
+                <%= h(post.display_nickname.presence || "名無しさん") %>
               </span>
             </div>
             <% if highlighted %>
@@ -23,16 +26,21 @@
             <% end %>
           </div>
 
-          <p class="text-body-md text-textPrimary whitespace-pre-wrap"><%= post.content %></p>
+          <!-- ユーザー入力は必ずエスケープ -->
+          <p class="text-body-md text-textPrimary whitespace-pre-wrap"><%= h post.content %></p>
 
           <div class="flex items-center justify-between mt-3">
-            <span class="text-label-sm text-textSecondary"><%= l(post.created_at, format: :short) %></span>
+            <!-- JSTで表示（アプリ設定が未調整でも確実に日本時間で出す） -->
+            <span class="text-label-sm text-textSecondary">
+              <%= l(post.created_at.in_time_zone("Tokyo"), format: :short) %>
+            </span>
             <div class="flex items-center gap-1 text-textSecondary">
               <%= lucide_icon("heart", class: "w-4 h-4") %>
-              <span class="text-label-sm">0</span> <%# ← MVPではプレースホルダ %>
+              <span class="text-label-sm">0</span> <%# MVPではプレースホルダ %>
             </div>
           </div>
         </article>
+
       <% end %>
 
       <% if @posts.blank? %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -5,18 +5,18 @@
     <h1 class="text-heading-lg font-semibold text-textPrimary">日常のひとコマで練習</h1>
     <% if @tip %>
       <p class="text-body-md text-textSecondary mt-1">
-        今日のひとこと：<span class="text-textPrimary"><%= @tip.content %></span>
+        今日のひとこと：<span class="text-textPrimary"><%= h(@tip.title) %></span>
       </p>
     <% else %>
       <p class="text-body-md text-textSecondary mt-1">投稿対象のひとことが見つかりません。</p>
     <% end %>
   </section>
 
-  <!-- シーン説明カード -->
+  <!-- シーン説明カード（Tip.practice_description を表示） -->
   <section class="bg-surface shadow-sm rounded-lg p-4 border border-neutralGray mb-4">
-    <p class="text-body-md text-textPrimary">
-      会議前のアイスブレイク。隣の人が同じペンを使っているのに気づいたとき、どう声をかけますか？
-    </p>
+    <div class="text-body-md text-textPrimary">
+      <%= simple_format(h(@tip&.practice_description.presence || "準備中")) %>
+    </div>
   </section>
 
   <% if flash[:notice] %>
@@ -27,22 +27,22 @@
   <% end %>
 
   <!-- ★ 投稿停止中の案内を追加 -->
-<% unless posts_enabled? %>
-  <div class="mb-4 p-3 rounded bg-neutralGray text-label-sm text-textSecondary">
-    現在、投稿は一時停止中です（画面表示や遷移のみ確認できます）。
-  </div>
-<% end %>
+  <% unless posts_enabled? %>
+    <div class="mb-4 p-3 rounded bg-neutralGray text-label-sm text-textSecondary">
+      現在、投稿は一時停止中です（画面表示や遷移のみ確認できます）。
+    </div>
+  <% end %>
 
   <%= form_with url: practice_path,
-              scope: :post,
-              method: :post,
-              data: { turbo: false },
-              class: "space-y-4" do |f| %>
+                scope: :post,
+                method: :post,
+                data: { turbo: false },
+                class: "space-y-4" do |f| %>
     <%= hidden_field_tag :tip_id, @tip&.id %>
 
     <!-- 自由入力 150字 -->
     <div>
-      <label class="block text-label-sm text-textSecondary mb-1">回答（150字）</label>
+      <label class="block text-label-sm text-textSecondary mb-1">あなたならどう話す？（150字以内）</label>
       <%= f.text_area :content,
             maxlength: 150,
             rows: 5,

--- a/app/views/shared/_common_header.html.erb
+++ b/app/views/shared/_common_header.html.erb
@@ -1,5 +1,5 @@
 <header class="h-14 bg-surface border-b border-neutralGray px-4 flex justify-between items-center">
-  <%= link_to 'カタトーク', root_path, class: 'text-heading-lg text-textPrimary font-semibold' %>
+  <%= link_to 'カタトーク', root_path, class: 'text-heading-lg text-accentBlue font-semibold' %>
   <button data-action="click->sidebar#toggle" aria-label="メニュー" class="p-2">
     <%= lucide_icon("menu", class: "w-6 h-6 text-textSecondary") %>
   </button>

--- a/app/views/tips/index.html.erb
+++ b/app/views/tips/index.html.erb
@@ -16,11 +16,17 @@
     <% @tips.each_with_index do |tip, i| %>
       <%= link_to drills_path(tip_id: tip.id),
                   class: "block bg-surface shadow-sm rounded-lg p-4 border border-neutralGray" do %>
+        <!-- タイトル -->
         <h3 class="text-body-md font-semibold text-textPrimary">
-          <%= tip.content.truncate(30) %>
+          <%= h tip.title %>
         </h3>
+        <!-- 説明文（追加） -->
+        <p class="text-body-md text-textSecondary mt-2">
+          <%= h((tip.description.presence || "準備中")).truncate(80) %>
+        </p>
+        <!-- メタ情報（既存どおり） -->
         <p class="text-label-sm text-textSecondary mt-1">
-          投稿日: <%= tip.scheduled_date %>　投稿数: <%= tip.posts.count %>
+          投稿日: <%= l(tip.scheduled_date) %>　投稿数: <%= tip.posts.count %>
         </p>
       <% end %>
 

--- a/app/views/tips/today.html.erb
+++ b/app/views/tips/today.html.erb
@@ -1,34 +1,45 @@
 <%= render "shared/common_header" %>
 
-<main class="p-4">
+<main class="p-4 pb-24">
   <% if @tip.present? %>
-    <h1 class="text-heading-lg font-semibold text-textPrimary mb-4">
-      <%= @tip.content %>
+    <!-- ページ見出し -->
+    <h1 class="text-heading-lg font-semibold text-textPrimary text-center mb-4">
+      今日のひとこと
     </h1>
 
+    <!-- TIPカード（タイトル＋説明） -->
+    <section class="rounded-2xl bg-gray-50 p-6 mb-10">
+      <h2 class="text-xl font-semibold text-textPrimary text-center mb-3">
+        <%= h @tip.title %>
+      </h2>
+      <div class="text-body-md text-textSecondary leading-relaxed">
+        <%= simple_format(h(@tip.description.presence || "準備中")) %>
+      </div>
+    </section>
+
+    <!-- 練習へ -->
     <%= link_to "このひとことで話してみる",
                 practice_path(tip_id: @tip.id),
                 class: "btn-primary mt-6 inline-flex w-full items-center justify-center text-center hover:bg-[#FF9F2E]" %>
 
+    <!-- 前後ナビ -->
+    <div class="flex justify-between mt-4">
+      <div>
+        <% if @prev_tip %>
+          <%= link_to "＜ 前のひとこと",
+                      today_path(date: @prev_tip.scheduled_date),
+                      class: "px-4 py-2 rounded-full border border-blue-500 text-blue-600 text-label-sm font-medium hover:bg-blue-50 transition" %>
+        <% end %>
+      </div>
 
-<div class="flex justify-between mt-4">
-  <div>
-    <% if @prev_tip %>
-      <%= link_to "◀ 前のひとこと",
-        today_path(date: @prev_tip.scheduled_date),
-        class: "px-4 py-2 rounded-full border border-blue-500 text-blue-600 text-label-sm font-medium hover:bg-blue-50 transition" %>
-    <% end %>
-  </div>
-
-  <div>
-    <% if @next_tip %>
-      <%= link_to "次のひとこと ▶",
-        today_path(date: @next_tip.scheduled_date),
-        class: "px-4 py-2 rounded-full border border-blue-500 text-blue-600 text-label-sm font-medium hover:bg-blue-50 transition" %>
-    <% end %>
-  </div>
-</div>
-
+      <div>
+        <% if @next_tip %>
+          <%= link_to "次のひとこと ＞",
+                      today_path(date: @next_tip.scheduled_date),
+                      class: "px-4 py-2 rounded-full border border-blue-500 text-blue-600 text-label-sm font-medium hover:bg-blue-50 transition" %>
+        <% end %>
+      </div>
+    </div>
   <% else %>
     <p class="text-body-md text-textSecondary">本日のひとことは準備中です</p>
   <% end %>

--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -4,7 +4,7 @@ bundle install
 bundle exec rails assets:precompile
 bundle exec rails assets:clean
 bundle exec rails db:migrate
-bundle exec rails db:seed   # ← 一時的に追加
+# bundle exec rails db:seed   # ← 一時的に追加
 # Render のケースでどちらを使う？
 # プロジェクトには bin/rails が存在しているので、
 # bin/rails db:seed の方が Rails Way で推奨。

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,10 @@ module Myapp
 
     config.autoload_lib(ignore: %w[assets tasks])
 
+    config.time_zone = "Tokyo"          # 表示はJST
+    # DBはUTCのまま推奨（既定）: config.active_record.default_timezone = :utc
+
+
     # --- Basic 認証（本番のみ）。ENV 未設定ならミドルウェアを積まない ---
     if Rails.env.production?
       user = ENV["BASIC_AUTH_USERNAME"] || ENV["BASIC_AUTH_USER"]

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,4 @@
+ja:
+  time:
+    formats:
+      short: "%m/%d %H:%M"


### PR DESCRIPTION
## 目的

Tips テーブル拡張に伴い、**旧 `content` 依存から `title/description/practice_description` への移行**を UI/表示面から先行実施します。あわせて並び替えロジックの堅牢化と投稿時刻の **JST 表示**に対応します。

## 変更内容

### モデル

* `app/models/tip.rb`

  * `content` の必須バリデーションを削除（**移行期間の暫定**。後続PRでカラム削除予定）
  * `TITLE_MAX = 120` による title 長さバリデーションを明示
  * ドキュメンテーションコメントを更新（`content` は DEPRECATED）

### コントローラ

* `app/controllers/tips_controller.rb`

  * `ORDER_OPTIONS` を導入し `order` パラメータをサニタイズ（`:recent` / `:likes` のみ許可）
  * `:likes` は `LEFT JOIN posts + COUNT(posts.id)` で null/0 件でも安定ソート
  * `show_today` の日付パースを私有メソッド化し例外安全に

### ビュー

* `app/views/tips/today.html.erb`

  * **title/description** を表示（旧 `content` を廃止）
  * 前後ナビ維持、軽微なクラス調整（中央寄せ・余白）
* `app/views/posts/new.html.erb`（練習）

  * シーン説明として **`@tip.practice_description`** を表示
  * ページ内の「今日のひとこと」は **`@tip.title`** に差し替え
* `app/views/posts/index.html.erb`（みんな）

  * ヘッダ部を **`@tip.title`** に差し替え
  * 投稿本文は `h()` でエスケープ
  * 投稿日時は **`post.created_at.in_time_zone("Tokyo")`** を `l(..., :short)` で表示
  * 自分の投稿の強調は **青枠**のまま（青地にする 1 行置換のコメントを同梱）
* `app/views/tips/index.html.erb`（一覧）

  * **title** の下に **description（抜粋）** を追加
  * 投稿日は `l(tip.scheduled_date)`、投稿数は現状どおり

## 動作確認

1. `tips#today`

   * 今日（or クエリ `?date=YYYY-MM-DD`）のページで **title/description** が表示されること
   * 前後ナビが機能すること
2. `posts#new`（練習ページ）

   * 見出しの横に **今日のひとこと：title** が出ること
   * シーン説明が **practice\_description** になること
3. `posts#index`（みんなのひとこと）

   * 上部に **title**、各投稿時刻が **JST** で表示されること
   * 自分の投稿は **青枠強調**（`highlight_post_id` が一致した記事）
4. `tips#index`（一覧）

   * 各カードに **title + description 抜粋** が表示されること
   * 並べ替えタブ「新着順/投稿数」が機能すること

## マイグレーション

* **本PRでは DB 変更なし**（表示面の移行のみ）
* 後続PRで以下を予定

  * 既存データバックフィル（title/description/practice\_description の補完）
  * `content` カラム削除（`RemoveContentFromTips`）

## 互換性とリスク

* 表示ロジックの変更のみ。`drills_path` への動線・URL は既存どおり。
* `content` 参照はビューから排除済み。コード上の残存参照は別箇所（管理画面/サービス）であれば後続で除去します。
* XSS対策として `h()` / `simple_format` を適用。

## 追加メモ

* アプリ全体を JST 表示に寄せる恒久対応は `config.time_zone = "Tokyo"` 推奨（別PRで）。
* 自分の投稿を**青地**にするデザイン切替は `posts/index.html.erb` のコメント指示どおり 1 行差し替えで対応可能。

## 関連タスク（残り）

* [ ] 既存 TIP データのバックフィル Migration 追加
* [ ] `content` カラム削除 Migration
* [ ] Strong Parameters（管理系で `title/description/practice_description` 許可を再確認）
* [ ] スタイル（カード表現の最終調整）

close #46 
