### PR TITLE
feat(db): add tips.day_of_month and backfill from scheduled_date (no behavior change)

### DIFF
--- a/db/migrate/20251113204424_add_day_of_month_to_tips.rb
+++ b/db/migrate/20251113204424_add_day_of_month_to_tips.rb
@@ -1,0 +1,10 @@
+# 日めくりTIP対応の準備として day_of_month を追加するマイグレーション
+class AddDayOfMonthToTips < ActiveRecord::Migration[7.2]
+  def change
+    # NULL許容（後続PRで NOT NULL / UNIQUE を付ける）
+    add_column :tips, :day_of_month, :integer
+
+    # 開発環境では通常インデックスでOK（本番ではCONCURRENTLYを別PR）
+    add_index :tips, :day_of_month
+  end
+end

--- a/db/migrate/20251118203025_backfill_day_of_month_to_tips.rb
+++ b/db/migrate/20251118203025_backfill_day_of_month_to_tips.rb
@@ -1,0 +1,27 @@
+# 既存の scheduled_date から day_of_month を埋めるバックフィル処理
+# 将来の「日めくりTIP」取得ロジックへスムーズに移行するための準備段階
+class BackfillDayOfMonthToTips < ActiveRecord::Migration[7.2]
+  def up
+    # 既存データのうち、scheduled_date が存在し
+    # かつ day_of_month がまだ NULL のレコードだけを更新する
+    #
+    # Postgres の EXTRACT 関数で日（1〜31）だけ取り出してセットする
+    execute <<~SQL
+      UPDATE tips
+        SET day_of_month = EXTRACT(DAY FROM scheduled_date)
+      WHERE scheduled_date IS NOT NULL
+        AND day_of_month IS NULL;
+    SQL
+  end
+
+  def down
+    # バックフィルの巻き戻し
+    # day_of_month を NULL に戻すだけのシンプルな処理
+    #
+    # これにより "バックフィル前の状態" を再現できる
+    execute <<~SQL
+      UPDATE tips
+        SET day_of_month = NULL;
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_10_21_205903) do
+ActiveRecord::Schema[7.2].define(version: 2025_11_18_203025) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -32,6 +32,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_21_205903) do
     t.string "title", null: false, comment: "TIPのタイトル"
     t.text "description", null: false, comment: "TIPの背景/説明文"
     t.text "practice_description", null: false, comment: "TIPの練習用シナリオ/説明文"
+    t.integer "day_of_month"
+    t.index ["day_of_month"], name: "index_tips_on_day_of_month"
     t.index ["scheduled_date"], name: "index_tips_on_scheduled_date", unique: true
     t.check_constraint "char_length(title::text) <= 120", name: "tips_title_length_check"
   end


### PR DESCRIPTION
### 🧩 概要
日めくりTIP対応（1〜31日）への移行準備として、`tips.day_of_month` を追加し、
既存データから安全にバックフィルするためのPRです。
※ このPRではアプリ挙動の変更はありません。

---

### 🛠 実施内容
- `tips.day_of_month :integer` を追加（NULL許容）
- `day_of_month` に通常インデックスを付与
- `scheduled_date` → `day_of_month` へのバックフィルを実行
  - `EXTRACT(DAY FROM scheduled_date)` により1〜31を設定
- マイグレーションはロールバック可能

---

## やっていないこと（後続PRで対応）
- NOT NULL / UNIQUE 制約の付与（PR4）
- TIP取得ロジックの `day_of_month` 版への切替（PR2）
- seeds.rb の洗い替え（PR3）

---

### ✅ 確認項目
- `rails db:migrate` が正常に通ること
- `Tip.where.not(scheduled_date: nil).pluck(:scheduled_date, :day_of_month)`  
  → 日付の“日”が一致していることを確認
- `day_of_month` は 1〜31 の範囲内
- `scheduled_date IS NULL` のレコードは更新されていない

---

## ロールバック
rails db:migrate:down VERSION=xxxxxxxxxxxx
で `day_of_month` とバックフィルを巻き戻し可能です。

---

## 補足
本PRは「スキーマ追加＋データ整備」のみで、アプリの挙動に変化はありません。
後続PRで安全にロジック差し替えができるよう、非破壊的な構成にしています。

---

### 🔗 関連Issue
close #142 